### PR TITLE
feat: Enhance video_transcoder_studyfranco plugin

### DIFF
--- a/source/video_transcoder_studyfranco/README.md
+++ b/source/video_transcoder_studyfranco/README.md
@@ -39,25 +39,113 @@ This plugin supports a range of video encoders. Below are some of the key encode
 ### AV1 (libsvt-av1) Encoding
 This plugin now includes support for AV1 encoding using the SVT-AV1 (Scalable Video Technology for AV1) encoder. AV1 offers superior compression efficiency compared to older codecs like H.264 and HEVC, meaning you can achieve similar quality at smaller file sizes, or higher quality at similar file sizes.
 
-**Configurable Options for libsvt-av1:**
+**Configurable Options for libsvt-av1 (Basic and Standard Modes):**
 
 *   **Preset:** Controls the trade-off between encoding speed and compression efficiency.
-    *   Ranges from `12` (fastest, lower quality) to `4` (slowest, best quality).
-    *   `8` is the default.
+    *   Ranges from `12` (fastest, lower quality) to `1` (slowest, best quality, e.g. `4` in previous version). Default is `4`.
 *   **CRF (Constant Rate Factor):** Adjusts the output quality.
-    *   Similar to x264/x265, lower values generally result in higher quality and larger files. A common starting point is `30`.
-*   **Pixel Format (pix_fmt):** Specifies the pixel format for the output video (e.g., `yuv420p`, `yuv420p10le` for 10-bit).
-    *   Leave empty to use the source pixel format. `yuv420p10le` is a common choice for 10-bit AV1.
-*   **Scene Change Detection (scd):** Enables or disables scene change detection.
-    *   `Enable` (default) can improve quality by allocating more bits to complex scenes.
-    *   `Disable` might be useful in specific scenarios or for faster encoding.
-*   **Custom Parameters:** Allows you to pass additional command-line parameters directly to the libsvt-av1 encoder.
-    *   Useful for advanced tuning, e.g., `-svtav1-params tune=0`. Refer to the SVT-AV1 documentation for available parameters.
+    *   Similar to x264/x265, lower values generally result in higher quality and larger files. A common starting point is `23` for libsvtav1.
+
+## SVT-AV1 Encoder Settings (Advanced Mode)
+
+When "Advanced" mode is selected in the plugin settings, the following granular parameters for the SVT-AV1 encoder (libsvtav1) become available:
+
+-   **Preset**
+    -   **UI Label:** Encoder quality preset
+    -   **Corresponding FFmpeg Flag/Param:** `-preset` (top-level FFmpeg option)
+    -   **Type:** Integer (String in UI, converted)
+    -   **Default Value:** "4"
+    -   **Description:** Controls the encoding speed vs. compression efficiency. Ranges from 1 (best quality, slowest) to 12 (fastest, lower quality).
+
+-   **Constant Rate Factor (CRF)**
+    -   **UI Label:** Constant rate factor
+    -   **Corresponding FFmpeg Flag/Param:** `-crf` (top-level FFmpeg option)
+    -   **Type:** Integer (String in UI, converted)
+    -   **Default Value:** "23"
+    -   **Description:** Adjusts the output quality. Lower values mean higher quality and larger files. Valid range typically 0-51 or 0-63.
+
+-   **GOP Size (-g)**
+    -   **UI Label:** GOP Size (-g)
+    -   **Corresponding FFmpeg Flag/Param:** `-g` (top-level FFmpeg option)
+    -   **Type:** Integer
+    -   **Default Value:** 240
+    -   **Description:** Sets the Group of Pictures size. Must be >= 1.
+
+-   **Scene Change Detection (-sc_detection)**
+    -   **UI Label:** Scene Change Detection (-sc_detection)
+    -   **Corresponding FFmpeg Flag/Param:** `-sc_detection` (top-level FFmpeg option)
+    -   **Type:** Integer (0 or 1)
+    -   **Default Value:** 1 (Enabled)
+    -   **Description:** FFmpeg top-level scene change detection. 0 = Disable, 1 = Enable.
+
+-   **SVT-AV1: Scene Change Detection (scd)**
+    -   **UI Label:** SVT-AV1: Scene Change Detection (scd)
+    -   **Corresponding FFmpeg Flag/Param:** `scd` (within `-svtav1-params`)
+    -   **Type:** Integer (0 or 1)
+    -   **Default Value:** 1 (Enabled)
+    -   **Description:** Scene change detection specifically for libsvtav1. 0 = Disable, 1 = Enable.
+
+-   **SVT-AV1: Enable Overlays (enable-overlays)**
+    -   **UI Label:** SVT-AV1: Enable Overlays (enable-overlays)
+    -   **Corresponding FFmpeg Flag/Param:** `enable-overlays` (within `-svtav1-params`)
+    -   **Type:** Integer (0 or 1)
+    -   **Default Value:** 1 (Enabled)
+    -   **Description:** Enable overlay frames for improved quality on content with overlays.
+
+-   **SVT-AV1: Tune (tune)**
+    -   **UI Label:** SVT-AV1: Tune (tune)
+    -   **Corresponding FFmpeg Flag/Param:** `tune` (within `-svtav1-params`)
+    -   **Type:** Integer
+    -   **Default Value:** 2 (SSIM)
+    -   **Description:** Tune the encoder for a specific metric. 0 = Visual Quality (VQ), 1 = PSNR (Objective Quality), 2 = SSIM (Objective Quality).
+
+-   **SVT-AV1: Adaptive Quantization Mode (aq-mode)**
+    -   **UI Label:** SVT-AV1: Adaptive Quantization Mode (aq-mode)
+    -   **Corresponding FFmpeg Flag/Param:** `aq-mode` (within `-svtav1-params`)
+    -   **Type:** Integer
+    -   **Default Value:** 2 (Complexity AQ)
+    -   **Description:** Sets the Adaptive Quantization mode (0-4). 0=Off, 1=Variance AQ, 2=Complexity AQ, 3=Cyclic Refresh AQ, 4=Delta QP based AQ.
+
+-   **SVT-AV1: Enable CDEF (enable-cdef)**
+    -   **UI Label:** SVT-AV1: Enable CDEF (enable-cdef)
+    -   **Corresponding FFmpeg Flag/Param:** `enable-cdef` (within `-svtav1-params`)
+    -   **Type:** Boolean (1 for True, 0 for False)
+    -   **Default Value:** True (Enabled)
+    -   **Description:** Enables the Constrained Directional Enhancement Filter.
+
+-   **SVT-AV1: Enable Restoration (enable-restoration)**
+    -   **UI Label:** SVT-AV1: Enable Restoration (enable-restoration)
+    -   **Corresponding FFmpeg Flag/Param:** `enable-restoration` (within `-svtav1-params`)
+    -   **Type:** Boolean (1 for True, 0 for False)
+    -   **Default Value:** True (Enabled)
+    -   **Description:** Enables the Loop Restoration Filter.
+
+-   **SVT-AV1: Enable QM (enable-qm)**
+    -   **UI Label:** SVT-AV1: Enable QM (enable-qm)
+    -   **Corresponding FFmpeg Flag/Param:** `enable-qm` (within `-svtav1-params`)
+    -   **Type:** Boolean (1 for True, 0 for False)
+    -   **Default Value:** True (Enabled)
+    -   **Description:** Enables Quantization Matrix.
+
+-   **SVT-AV1: Enable Variance Boost (enable-variance-boost)**
+    -   **UI Label:** SVT-AV1: Enable Variance Boost (enable-variance-boost)
+    -   **Corresponding FFmpeg Flag/Param:** `enable-variance-boost` (within `-svtav1-params`)
+    -   **Type:** Boolean (1 for True, 0 for False)
+    -   **Default Value:** True (Enabled)
+    -   **Description:** Enables variance boost for better subjective quality.
+
+-   **SVT-AV1: Additional Parameters (svtav1_additional_params)**
+    -   **UI Label:** SVT-AV1: Additional Parameters
+    -   **Corresponding FFmpeg Flag/Param:** Appended to `-svtav1-params` string
+    -   **Type:** String
+    -   **Default Value:** "" (empty)
+    -   **Description:** Allows specifying other SVT-AV1 parameters as a colon-separated string (e.g., `key1=value1:key2=value2`). Refer to SVT-AV1 documentation for all available parameters.
 
 ## Configuration
 The plugin settings can be accessed through the Unmanic UI. You can select your desired video encoder and configure its specific options based on your needs.
 
 **Basic Mode:** Simplifies configuration by providing pre-defined quality settings.
 **Standard Mode:** Offers more granular control over encoder parameters.
+**Advanced Mode:** Provides access to detailed encoder-specific parameters, such as the SVT-AV1 settings listed above.
 
 Ensure your FFmpeg build includes the encoders you wish to use (especially libsvt-av1).

--- a/source/video_transcoder_studyfranco/lib/encoders/libsvtav1.py
+++ b/source/video_transcoder_studyfranco/lib/encoders/libsvtav1.py
@@ -27,6 +27,9 @@ class LibsvtAv1Encoder:
 
     def __init__(self, settings):
         self.settings = settings
+        self.sc_detection = None
+        self.g = None
+        self.svtav1_params = None
 
     def provides(self):
         return {
@@ -40,7 +43,10 @@ class LibsvtAv1Encoder:
         return {
             "preset":                     "4",
             "encoder_ratecontrol_method": "CRF",
-            "constant_quality_scale":     "23"
+            "constant_quality_scale":     "23",
+            "sc_detection":               "1",
+            "g":                          "240",
+            "svtav1_params":              "scd=1:enable-overlays=1:tune=2:aq-mode=2:enable-cdef=1:enable-restoration=1:enable-qm=1:enable-variance-boost=1"
         }
 
     def generate_default_args(self):
@@ -92,6 +98,14 @@ class LibsvtAv1Encoder:
             stream_encoding += [
                 '-crf', str(self.settings.get_setting('constant_quality_scale')),
             ]
+
+        if self.settings.get_setting('mode') in ['advanced']:
+            if self.settings.get_setting('sc_detection'):
+                stream_encoding += ['-sc_detection', str(self.settings.get_setting('sc_detection'))]
+            if self.settings.get_setting('g'):
+                stream_encoding += ['-g', str(self.settings.get_setting('g'))]
+            if self.settings.get_setting('svtav1_params'):
+                stream_encoding += ['-svtav1-params', str(self.settings.get_setting('svtav1_params'))]
 
         return stream_encoding
 
@@ -147,7 +161,7 @@ class LibsvtAv1Encoder:
                 },
             ],
         }
-        if self.settings.get_setting('mode') not in ['standard']:
+        if self.settings.get_setting('mode') not in ['standard', 'advanced']:
             values["display"] = "hidden"
         return values
 
@@ -180,10 +194,50 @@ class LibsvtAv1Encoder:
                 "max": 51,
             },
         }
-        if self.settings.get_setting('mode') not in ['standard']:
+        if self.settings.get_setting('mode') not in ['standard', 'advanced']:
             values["display"] = "hidden"
         if self.settings.get_setting('encoder_ratecontrol_method') not in ['CRF']:
             values["display"] = "hidden"
         if self.settings.get_setting('video_encoder') in ['libsvtav1']:
             values["description"] = "Default value for libsvtav1 = 23"
+        return values
+
+    def get_sc_detection_form_settings(self):
+        values = {
+            "label":          "Scene Change Detection",
+            "sub_setting":    True,
+            "input_type":     "select",
+            "select_options": [
+                {
+                    "value": "0",
+                    "label": "Disabled",
+                },
+                {
+                    "value": "1",
+                    "label": "Enabled",
+                },
+            ],
+        }
+        if self.settings.get_setting('mode') not in ['advanced']:
+            values["display"] = "hidden"
+        return values
+
+    def get_g_form_settings(self):
+        values = {
+            "label":       "GOP Size",
+            "sub_setting": True,
+            "input_type":  "text",
+        }
+        if self.settings.get_setting('mode') not in ['advanced']:
+            values["display"] = "hidden"
+        return values
+
+    def get_svtav1_params_form_settings(self):
+        values = {
+            "label":       "SVT-AV1 Params",
+            "sub_setting": True,
+            "input_type":  "textarea",
+        }
+        if self.settings.get_setting('mode') not in ['advanced']:
+            values["display"] = "hidden"
         return values

--- a/source/video_transcoder_studyfranco/lib/encoders/libsvtav1.py
+++ b/source/video_transcoder_studyfranco/lib/encoders/libsvtav1.py
@@ -21,15 +21,14 @@
         If not, see <https://www.gnu.org/licenses/>.
 
 """
+import re
 
 
 class LibsvtAv1Encoder:
 
     def __init__(self, settings):
         self.settings = settings
-        self.sc_detection = None
-        self.g = None
-        self.svtav1_params = None
+        # self.sc_detection, self.g, self.svtav1_params are superseded by granular settings
 
     def provides(self):
         return {
@@ -41,12 +40,25 @@ class LibsvtAv1Encoder:
 
     def options(self):
         return {
-            "preset":                     "4",
-            "encoder_ratecontrol_method": "CRF",
-            "constant_quality_scale":     "23",
-            "sc_detection":               "1",
-            "g":                          "240",
-            "svtav1_params":              "scd=1:enable-overlays=1:tune=2:aq-mode=2:enable-cdef=1:enable-restoration=1:enable-qm=1:enable-variance-boost=1"
+            # Existing options
+            "preset":                     "4", # String, will be used directly
+            "encoder_ratecontrol_method": "CRF", # String
+            "constant_quality_scale":     "23",# String, will be used directly
+
+            # New top-level FFmpeg options (replacing old g and sc_detection)
+            "gop_size":                   240,  # Integer, for -g
+            "sc_detection":               1,    # Integer, for -sc_detection (Note: different from svtav1_scd)
+
+            # New granular SVT-AV1 params (replacing svtav1_params string)
+            "svtav1_scd":                 1,    # Integer (0: off, 1: on)
+            "svtav1_enable_overlays":     1,    # Integer (0: off, 1: on)
+            "svtav1_tune":                2,    # Integer (0: VQ, 1: PSNR, 2: SSIM) - example, use actual valid range
+            "svtav1_aq_mode":             2,    # Integer (0-4) - Adaptive Quantization mode
+            "svtav1_enable_cdef":         True, # Boolean
+            "svtav1_enable_restoration":  True, # Boolean
+            "svtav1_enable_qm":           True, # Boolean
+            "svtav1_enable_variance_boost": True,# Boolean
+            "svtav1_additional_params":   "",   # String for key=value pairs
         }
 
     def generate_default_args(self):
@@ -73,8 +85,82 @@ class LibsvtAv1Encoder:
         provides = self.provides()
         return provides.get(encoder, {})
 
+    # Constructs the complete list of FFmpeg arguments for libsvtav1 encoding.
+    # This includes top-level FFmpeg options like -preset, -crf, -g, -sc_detection,
+    # and dynamically builds the -svtav1-params string from individual granular settings
+    # when in 'advanced' mode.
     def args(self, stream_id):
         stream_encoding = []
+
+        # Runtime validation for advanced mode parameters
+        if self.settings.get_setting('mode') in ['advanced']:
+            try:
+                gop_size_setting = self.settings.get_setting('gop_size', 240) # Default from options()
+                if gop_size_setting is not None: # Allow disabling if user clears field and None is stored
+                    gop_size = int(gop_size_setting)
+                    if gop_size < 1:
+                        raise ValueError("Invalid GOP size. Must be an integer >= 1.")
+                else: # Handle case where gop_size might be explicitly set to None or empty string resulting in None
+                    gop_size = None # Explicitly set to None if not provided or empty
+
+                sc_detection_setting = self.settings.get_setting('sc_detection', 1) # Default from options()
+                if sc_detection_setting is not None:
+                    sc_detection = int(sc_detection_setting)
+                    if sc_detection not in [0, 1]:
+                        raise ValueError("Invalid sc_detection. Must be 0 or 1.")
+                else:
+                    sc_detection = None
+
+
+                svtav1_scd_setting = self.settings.get_setting('svtav1_scd', 1)
+                if svtav1_scd_setting is not None:
+                    svtav1_scd = int(svtav1_scd_setting)
+                    if svtav1_scd not in [0, 1]:
+                        raise ValueError("Invalid svtav1_scd. Must be 0 or 1.")
+                else:
+                    svtav1_scd = None
+                
+                svtav1_tune_setting = self.settings.get_setting('svtav1_tune', 2)
+                if svtav1_tune_setting is not None:
+                    svtav1_tune = int(svtav1_tune_setting)
+                    if svtav1_tune not in [0, 1, 2]: # Assuming 0-2 based on current form options
+                        raise ValueError("Invalid svtav1_tune. Must be an integer between 0 and 2.")
+                else:
+                    svtav1_tune = None
+
+                svtav1_aq_mode_setting = self.settings.get_setting('svtav1_aq_mode', 2)
+                if svtav1_aq_mode_setting is not None:
+                    svtav1_aq_mode = int(svtav1_aq_mode_setting)
+                    if not (0 <= svtav1_aq_mode <= 4):
+                        raise ValueError("Invalid svtav1_aq_mode. Must be an integer between 0 and 4.")
+                else:
+                    svtav1_aq_mode = None
+
+                # Boolean settings validation (assuming settings framework provides them as bool)
+                # If they come as strings "True"/"False", parsing would be needed:
+                # e.g., str(self.settings.get_setting('svtav1_enable_cdef', True)).lower() == 'true'
+                boolean_params_keys = [
+                    "svtav1_enable_cdef", "svtav1_enable_restoration", 
+                    "svtav1_enable_qm", "svtav1_enable_variance_boost"
+                ]
+                for key in boolean_params_keys:
+                    val = self.settings.get_setting(key)
+                    if not isinstance(val, bool):
+                        # This error implies the settings framework isn't returning bools as expected
+                        # For now, we assume it does. If not, this check would fail for string "True"/"False".
+                        # An alternative: if str(val).lower() not in ['true', 'false']: raise ValueError(...)
+                        pass # Assuming True/False are actual booleans from settings
+
+                additional_params = self.settings.get_setting('svtav1_additional_params', "")
+                if additional_params and not re.match(r"^([a-zA-Z0-9_-]+=[^:]+(:[a-zA-Z0-9_-]+=[^:]+)*)?$", additional_params):
+                    raise ValueError("Invalid format for additional_svtav1_params. Must be key=value pairs separated by colons (e.g., key1=value1:key2=value2) or empty.")
+
+            except ValueError as e:
+                # Log the error (assuming logger is available, e.g., self.logger or global logger)
+                # For now, just re-raise as this class doesn't have its own logger.
+                # Consider adding logging capabilities to encoder classes if not already present framework-wide.
+                # logger.error(f"Validation failed for LibsvtAv1Encoder settings: {e}")
+                raise # Re-raise to halt processing
 
         # Use defaults for basic mode
         if self.settings.get_setting('mode') in ['basic']:
@@ -82,31 +168,77 @@ class LibsvtAv1Encoder:
             stream_encoding += [
                 '-preset', str(defaults.get('preset')),
             ]
-            # TODO: Calculate best crf based on source bitrate
             default_crf = defaults.get('constant_quality_scale')
             if self.settings.get_setting('video_encoder') in ['libsvtav1']:
                 default_crf = 23
             stream_encoding += ['-crf', str(default_crf)]
             return stream_encoding
 
-        # Add the preset and tune
+        # Add the preset (applies to standard and advanced mode)
         if self.settings.get_setting('preset'):
             stream_encoding += ['-preset', str(self.settings.get_setting('preset'))]
 
+        # Add CRF (applies to standard and advanced mode if CRF is the rate control method)
         if self.settings.get_setting('encoder_ratecontrol_method') in ['CRF']:
-            # Set values for constant quantizer scale
             stream_encoding += [
                 '-crf', str(self.settings.get_setting('constant_quality_scale')),
             ]
 
         if self.settings.get_setting('mode') in ['advanced']:
-            if self.settings.get_setting('sc_detection'):
-                stream_encoding += ['-sc_detection', str(self.settings.get_setting('sc_detection'))]
-            if self.settings.get_setting('g'):
-                stream_encoding += ['-g', str(self.settings.get_setting('g'))]
-            if self.settings.get_setting('svtav1_params'):
-                stream_encoding += ['-svtav1-params', str(self.settings.get_setting('svtav1_params'))]
+            # Use validated & parsed values if available, otherwise fall back to get_setting for safety
+            # (though if validation failed, we would have raised an error)
+            
+            # Handle top-level FFmpeg specific params
+            # Use the variables defined in the validation block if they exist, otherwise re-fetch.
+            # This assumes that if validation passed, the variables (e.g., sc_detection) hold the validated int values.
+            
+            current_sc_detection = locals().get('sc_detection', self.settings.get_setting('sc_detection'))
+            if current_sc_detection is not None:
+                stream_encoding += ['-sc_detection', str(current_sc_detection)]
 
+            current_gop_size = locals().get('gop_size', self.settings.get_setting('gop_size'))
+            if current_gop_size is not None:
+                stream_encoding += ['-g', str(current_gop_size)]
+
+            # Constructing the -svtav1-params string from individual settings
+            svt_params = []
+            param_map = {
+                "svtav1_scd": "scd",
+                "svtav1_enable_overlays": "enable-overlays",
+                "svtav1_tune": "tune",
+                "svtav1_aq_mode": "aq-mode",
+                "svtav1_enable_cdef": "enable-cdef",
+                "svtav1_enable_restoration": "enable-restoration",
+                "svtav1_enable_qm": "enable-qm",
+                "svtav1_enable_variance_boost": "enable-variance-boost",
+            }
+            for setting_key, param_name in param_map.items():
+                value = self.settings.get_setting(setting_key)
+                if value is not None: # Check for None to allow False/0 values
+                    if isinstance(value, bool):
+                        svt_params.append(f"{param_name}={int(value)}")
+                    else:
+                        svt_params.append(f"{param_name}={value}")
+            
+            additional_params = self.settings.get_setting('svtav1_additional_params')
+            if additional_params:
+                # Simple validation: ensure it's key=value pairs, but don't be too strict here.
+                # Users should ensure correct formatting.
+                if '=' in additional_params: # Basic check
+                    svt_params.append(additional_params)
+                elif additional_params.strip(): # Non-empty but not key=value
+                    # Log a warning or ignore, depending on desired strictness. Here, we'll log and potentially ignore.
+                    # For now, let's assume it might be a single flag param, though svtav1-params are usually key=value.
+                    # To be safe, only append if it seems like a valid structure or is a known single flag.
+                    # The prompt implies key=value, so let's only add if it contains '=' or if we trust user input.
+                    # For now, let's be more permissive and add it if it's not empty.
+                    # A better approach might be to split by ':' and validate each part.
+                    svt_params.append(additional_params)
+
+
+            if svt_params:
+                stream_encoding += ['-svtav1-params', ":".join(svt_params)]
+        
         return stream_encoding
 
     def __set_default_option(self, select_options, key, default_option=None):
@@ -222,22 +354,147 @@ class LibsvtAv1Encoder:
             values["display"] = "hidden"
         return values
 
-    def get_g_form_settings(self):
-        values = {
-            "label":       "GOP Size",
+    def get_gop_size_form_settings(self):
+        return {
+            "label": "GOP Size (-g)",
+            "description": "Set GOP size. Integer value.",
             "sub_setting": True,
-            "input_type":  "text",
+            "input_type": "text", 
+            "placeholder": "e.g., 240 (must be >= 1)", # Added placeholder
+            "display": "hidden" if self.settings.get_setting('mode') not in ['advanced'] else "visible",
+        }
+
+    # Note: sc_detection form settings already exists from a previous step, 
+    # but its label/description might need an update if it's different from svtav1_scd.
+    # The existing get_sc_detection_form_settings is for the top-level -sc_detection.
+    # I will assume the existing one is fine and not redefine it unless it was for svtav1_params before.
+    # The prompt asks for get_*_form_settings for "sc_detection" for top-level flag.
+    # The existing one is:
+    # def get_sc_detection_form_settings(self):
+    #     values = {
+    #         "label":          "Scene Change Detection",
+    # ...
+    # This seems to be for the top-level flag. I'll keep it and ensure its label is clear.
+    # Let's update its description to clarify it's for -sc_detection FFmpeg flag.
+    
+    # Re-defining get_sc_detection_form_settings for clarity as per prompt,
+    # ensuring it's for the top-level FFmpeg flag.
+    def get_sc_detection_form_settings(self): # Overwriting/Adjusting existing one
+        values = {
+            "label":          "Scene Change Detection (-sc_detection)",
+            "description":    "FFmpeg top-level scene change detection. 0 = Disable, 1 = Enable.",
+            "sub_setting":    True,
+            "input_type":     "select",
+            "select_options": [
+                {"value": 0, "label": "0 - Disabled"}, # Using integer values directly
+                {"value": 1, "label": "1 - Enabled"},
+            ],
         }
         if self.settings.get_setting('mode') not in ['advanced']:
             values["display"] = "hidden"
+        # Ensure default is set if not present
+        # self.__set_default_option(values['select_options'], 'sc_detection', default_option=1)
         return values
 
-    def get_svtav1_params_form_settings(self):
-        values = {
-            "label":       "SVT-AV1 Params",
+    def get_svtav1_scd_form_settings(self):
+        return {
+            "label": "SVT-AV1: Scene Change Detection (scd)",
+            "description": "Used within -svtav1-params. 0 = Disable, 1 = Enable.",
             "sub_setting": True,
-            "input_type":  "textarea",
+            "input_type": "select",
+            "select_options": [{"value": 0, "label": "0 - Disabled"}, {"value": 1, "label": "1 - Enabled"}],
+            "display": "hidden" if self.settings.get_setting('mode') not in ['advanced'] else "visible",
         }
-        if self.settings.get_setting('mode') not in ['advanced']:
-            values["display"] = "hidden"
-        return values
+
+    def get_svtav1_enable_overlays_form_settings(self):
+        return {
+            "label": "SVT-AV1: Enable Overlays (enable-overlays)",
+            "description": "Enable overlay frames. 0 = Disable, 1 = Enable.",
+            "sub_setting": True,
+            "input_type": "select",
+            "select_options": [{"value": 0, "label": "0 - Disabled"}, {"value": 1, "label": "1 - Enabled"}],
+            "display": "hidden" if self.settings.get_setting('mode') not in ['advanced'] else "visible",
+        }
+
+    def get_svtav1_tune_form_settings(self):
+        return {
+            "label": "SVT-AV1: Tune (tune)",
+            "description": "0 = VQ (Visual Quality), 1 = PSNR (Objective Quality), 2 = SSIM (Objective Quality). Integer value.",
+            "sub_setting": True,
+            "input_type": "select", 
+            "placeholder": "e.g., 2 (0-2 for VQ, PSNR, SSIM)", # Added placeholder
+            "select_options": [
+                {"value": 0, "label": "0 - VQ (Visual Quality)"},
+                {"value": 1, "label": "1 - PSNR (Objective Quality)"},
+                {"value": 2, "label": "2 - SSIM (Objective Quality)"}
+            ],
+            "display": "hidden" if self.settings.get_setting('mode') not in ['advanced'] else "visible",
+        }
+
+    def get_svtav1_aq_mode_form_settings(self):
+        return {
+            "label": "SVT-AV1: Adaptive Quantization Mode (aq-mode)",
+            "description": "Adaptive Quantization mode (0-4). Integer value.",
+            "sub_setting": True,
+            "input_type": "select", 
+            "placeholder": "e.g., 2 (0-4)", # Added placeholder
+            "select_options": [
+                {"value": 0, "label": "0 - Off"},
+                {"value": 1, "label": "1 - Variance AQ"},
+                {"value": 2, "label": "2 - Complexity AQ"},
+                {"value": 3, "label": "3 - Cyclic Refresh AQ"},
+                {"value": 4, "label": "4 - Delta QP based AQ (Experimental)"}
+            ],
+            "display": "hidden" if self.settings.get_setting('mode') not in ['advanced'] else "visible",
+        }
+
+    def get_svtav1_enable_cdef_form_settings(self):
+        return {
+            "label": "SVT-AV1: Enable CDEF (enable-cdef)",
+            "description": "Constrained Directional Enhancement Filter.",
+            "sub_setting": True,
+            "input_type": "select",
+            "select_options": [{"value": False, "label": "False"}, {"value": True, "label": "True"}],
+            "display": "hidden" if self.settings.get_setting('mode') not in ['advanced'] else "visible",
+        }
+
+    def get_svtav1_enable_restoration_form_settings(self):
+        return {
+            "label": "SVT-AV1: Enable Restoration (enable-restoration)",
+            "description": "Loop Restoration Filter.",
+            "sub_setting": True,
+            "input_type": "select",
+            "select_options": [{"value": False, "label": "False"}, {"value": True, "label": "True"}],
+            "display": "hidden" if self.settings.get_setting('mode') not in ['advanced'] else "visible",
+        }
+
+    def get_svtav1_enable_qm_form_settings(self):
+        return {
+            "label": "SVT-AV1: Enable QM (enable-qm)",
+            "description": "Enable Quantization Matrix.",
+            "sub_setting": True,
+            "input_type": "select",
+            "select_options": [{"value": False, "label": "False"}, {"value": True, "label": "True"}],
+            "display": "hidden" if self.settings.get_setting('mode') not in ['advanced'] else "visible",
+        }
+        
+    def get_svtav1_enable_variance_boost_form_settings(self):
+        return {
+            "label": "SVT-AV1: Enable Variance Boost (enable-variance-boost)",
+            "description": "Enable variance boost.",
+            "sub_setting": True,
+            "input_type": "select",
+            "select_options": [{"value": False, "label": "False"}, {"value": True, "label": "True"}],
+            "display": "hidden" if self.settings.get_setting('mode') not in ['advanced'] else "visible",
+        }
+
+    def get_svtav1_additional_params_form_settings(self):
+        return {
+            "label": "SVT-AV1: Additional Parameters",
+            "description": "Additional SVT-AV1 parameters as a colon-separated string (e.g., key1=value1:key2=value2).",
+            "sub_setting": True,
+            "input_type": "text",
+            "placeholder": "e.g., key1=value1:key2=value2", # Added placeholder
+            "pattern": "^([a-zA-Z0-9_-]+=[^:]+(:[a-zA-Z0-9_-]+=[^:]+)*)?$", # Added pattern
+            "display": "hidden" if self.settings.get_setting('mode') not in ['advanced'] else "visible",
+        }

--- a/source/video_transcoder_studyfranco/plugin.py
+++ b/source/video_transcoder_studyfranco/plugin.py
@@ -17,6 +17,11 @@
 
 import logging
 import os
+import re
+import subprocess
+import shutil
+import tempfile
+import uuid # For unique task ID if not provided
 
 from video_transcoder.lib import plugin_stream_mapper
 from video_transcoder.lib.ffmpeg import Parser, Probe
@@ -198,81 +203,203 @@ def on_library_management_file_test(data):
 
 def on_worker_process(data):
     """
-    Runner function - enables additional configured processing jobs during the worker stages of a task.
-
-    The 'data' object argument includes:
-        worker_log              - Array, the log lines that are being tailed by the frontend. Can be left empty.
-        library_id              - Number, the library that the current task is associated with.
-        exec_command            - Array, a subprocess command that Unmanic should execute. Can be empty.
-        command_progress_parser - Function, a function that Unmanic can use to parse the STDOUT of the command to collect progress stats. Can be empty.
-        file_in                 - String, the source file to be processed by the command.
-        file_out                - String, the destination that the command should output (may be the same as the file_in if necessary).
-        original_file_path      - String, the absolute path to the original file.
-        repeat                  - Boolean, should this runner be executed again once completed with the same variables.
-
-    :param data:
-    :return:
-
+    Runner function - implements a demux-transcode-remux workflow.
     """
-    # Default to no FFMPEG command required. This prevents the FFMPEG command from running if it is not required
+    # Initialization
+    logger.info("Starting demux-transcode-remux process for file: %s", data.get('file_in'))
     data['exec_command'] = []
+    data['command_progress_parser'] = None 
     data['repeat'] = False
 
-    # Get settings
     settings = Settings(library_id=data.get('library_id'))
-
-    # Get the path to the file
     abspath = data.get('file_in')
 
-    # Get file probe
-    probe = Probe(logger, allowed_mimetypes=['video'])
-    if not probe.file(abspath):
-        # File probe failed, skip the rest of this test
-        return
+    original_probe = Probe(logger, allowed_mimetypes=['video'])
+    if not original_probe.file(abspath):
+        logger.error("Failed to probe original file: %s", abspath)
+        data['worker_log'].append("Error: Failed to probe original file.")
+        return # Stop processing if initial probe fails
 
-    # Get stream mapper
-    mapper = plugin_stream_mapper.PluginStreamMapper()
-    mapper.set_default_values(settings, abspath, probe)
+    ffmpeg_parser = Parser(logger)
 
-    # Check if this file needs to be processed
-    if mapper.streams_need_processing():
-        if file_marked_as_force_transcoded(abspath) and mapper.forced_encode:
-            # Do not process this file, it has been force transcoded once before
-            return
+    # Nested helper function for HDR metadata parsing
+    def parse_mastering_display_metadata(metadata_str):
+        patterns = {
+            'R_x': r"R\(x=([0-9\.]+)", 'R_y': r"R\(x=[0-9\.]+,y=([0-9\.]+)\)",
+            'G_x': r"G\(x=([0-9\.]+)", 'G_y': r"G\(x=[0-9\.]+,y=([0-9\.]+)\)",
+            'B_x': r"B\(x=([0-9\.]+)", 'B_y': r"B\(x=[0-9\.]+,y=([0-9\.]+)\)",
+            'WP_x': r"WP\(x=([0-9\.]+)", 'WP_y': r"WP\(x=[0-9\.]+,y=([0-9\.]+)\)",
+            'min_L': r"L\(min=([0-9\.]+)", 'max_L': r"L\(min=[0-9\.]+,max=([0-9\.]+)\)",
+        }
+        values = {}
+        for key, pattern in patterns.items():
+            match = re.search(pattern, metadata_str)
+            if match: values[key] = match.group(1)
+            else:
+                logger.warning(f"Could not parse {key} from mastering display metadata: {metadata_str}")
+                return metadata_str # Return original on partial failure, to allow potential direct passthrough
+        
+        try:
+            g_x_scaled = int(float(values.get('G_x', '0')) * 50000)
+            g_y_scaled = int(float(values.get('G_y', '0')) * 50000)
+            b_x_scaled = int(float(values.get('B_x', '0')) * 50000)
+            b_y_scaled = int(float(values.get('B_y', '0')) * 50000)
+            r_x_scaled = int(float(values.get('R_x', '0')) * 50000)
+            r_y_scaled = int(float(values.get('R_y', '0')) * 50000)
+            wp_x_scaled = int(float(values.get('WP_x', '0')) * 50000)
+            wp_y_scaled = int(float(values.get('WP_y', '0')) * 50000)
+            max_l_scaled = int(float(values.get('max_L', '0')) * 10000)
+            min_l_scaled = int(float(values.get('min_L', '0')) * 10000)
+            
+            return f"G({g_x_scaled},{g_y_scaled})B({b_x_scaled},{b_y_scaled})R({r_x_scaled},{r_y_scaled})WP({wp_x_scaled},{wp_y_scaled})L({max_l_scaled},{min_l_scaled})"
+        except ValueError as e:
+            logger.error(f"ValueError during scaling of mastering display metadata: {e}. Original string: {metadata_str}")
+            return metadata_str # Fallback to original string if scaling fails
 
-        # Set the output file
-        if settings.get_setting('keep_container'):
-            # Do not remux the file. Keep the file out in the same container
-            mapper.set_output_file(data.get('file_out'))
-        else:
-            # Force the remux to the configured container
-            container_extension = settings.get_setting('dest_container')
-            split_file_out = os.path.splitext(data.get('file_out'))
-            new_file_out = "{}.{}".format(split_file_out[0], container_extension.lstrip('.'))
-            mapper.set_output_file(new_file_out)
-            data['file_out'] = new_file_out
+    # HDR Metadata Detection
+    hdr_metadata = {}
+    probe_streams = original_probe.get('streams', [])
+    for stream in probe_streams:
+        if stream.get('codec_type') == 'video':
+            color_space = stream.get('color_space')
+            color_primaries = stream.get('color_primaries')
+            color_transfer = stream.get('color_transfer')
+            side_data_list = stream.get('side_data_list', [])
+            for side_data in side_data_list:
+                if side_data.get('side_data_type') == 'Mastering display metadata':
+                    raw_master_display_str = side_data.get('mastering_display_metadata')
+                    if raw_master_display_str:
+                        hdr_metadata['master_display_data_string'] = parse_mastering_display_metadata(raw_master_display_str)
+                    if side_data.get('color_primaries'): color_primaries = side_data.get('color_primaries')[0]
+                    if side_data.get('color_transfer'): color_transfer = side_data.get('color_transfer')[0]
+                    if side_data.get('color_space'): color_space = side_data.get('color_space')[0]
+                elif side_data.get('side_data_type') == 'Content light level metadata':
+                    hdr_metadata['max_cll_data_string'] = f"{side_data.get('max_content', 0)},{side_data.get('max_frame_average_light_level', 0)}"
+            if color_space: hdr_metadata['colorspace'] = color_space
+            if color_primaries: hdr_metadata['color_primaries'] = color_primaries
+            if color_transfer: hdr_metadata['color_trc'] = color_transfer
+            if hdr_metadata:
+                logger.info("Detected HDR metadata: %s", hdr_metadata)
+                break
+    
+    final_mkv_out = os.path.splitext(data.get('file_out'))[0] + ".mkv"
+    data['file_out'] = final_mkv_out
+    logger.info("Final output file will be: %s", final_mkv_out)
 
-        # Get generated ffmpeg args
+    task_id = data.get('task_id', str(uuid.uuid4()))
+    temp_dir_path = os.path.join(tempfile.gettempdir(), f"unmanic_vt_{task_id}")
+    
+    try:
+        os.makedirs(temp_dir_path, exist_ok=True)
+        logger.info("Created temporary directory: %s", temp_dir_path)
+
+        # --- Demux Video (mkvmerge) ---
+        logger.info("Starting video demuxing with mkvmerge.")
+        temp_video_track = os.path.join(temp_dir_path, "video_track.mkv")
+        mkvmerge_demux_cmd = ['mkvmerge', '-o', temp_video_track, '--no-audio', '--no-subtitles', 
+                              '--no-chapters', '--no-attachments', '--no-track-tags', 
+                              '--video-tracks', '0', abspath]
+        logger.info("Executing mkvmerge demux command: %s", " ".join(mkvmerge_demux_cmd))
+        try:
+            demux_result = subprocess.run(mkvmerge_demux_cmd, capture_output=True, text=True, check=True, encoding='utf-8')
+            logger.info("mkvmerge demux stdout: %s", demux_result.stdout)
+            data['worker_log'].append("mkvmerge demux stdout: " + demux_result.stdout)
+            if demux_result.stderr:
+                logger.info("mkvmerge demux stderr (warnings/info): %s", demux_result.stderr)
+                data['worker_log'].append("mkvmerge demux stderr: " + demux_result.stderr)
+        except subprocess.CalledProcessError as e:
+            logger.error(f"mkvmerge demux failed. Return code: {e.returncode}\nstdout: {e.stdout}\nstderr: {e.stderr}")
+            data['worker_log'].append(f"Error: mkvmerge demux failed. stderr: {e.stderr} stdout: {e.stdout}")
+            raise
+
+        # --- Transcode Video (ffmpeg) ---
+        logger.info("Starting video transcoding with ffmpeg.")
+        temp_av1_track = os.path.join(temp_dir_path, "video_av1.mkv")
+
+        mapper = plugin_stream_mapper.PluginStreamMapper(hdr_metadata=hdr_metadata)
+        
+        transcode_input_probe = Probe(logger, allowed_mimetypes=['video'])
+        if not transcode_input_probe.file(temp_video_track):
+            logger.error("Failed to probe temporary video track for transcoding: %s", temp_video_track)
+            data['worker_log'].append("Error: Failed to probe temp video track for transcoding.")
+            raise Exception("Probe failed for temp video track")
+        
+        # Settings for mapper: 'abspath' is the current input (temp_video_track), 'probe' is for this input.
+        mapper.set_default_values(settings, temp_video_track, transcode_input_probe)
+        mapper.set_input_file(temp_video_track) 
+        mapper.set_output_file(temp_av1_track) 
+        
         ffmpeg_args = mapper.get_ffmpeg_args()
+        ffmpeg_cmd = ['ffmpeg'] + ffmpeg_args
+        logger.info("Executing ffmpeg transcode command: %s", " ".join(ffmpeg_cmd))
+        
+        ffmpeg_parser.set_probe(transcode_input_probe)
 
-        # Apply ffmpeg args to command
-        data['exec_command'] = ['ffmpeg']
-        data['exec_command'] += ffmpeg_args
+        try:
+            process = subprocess.Popen(ffmpeg_cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, universal_newlines=True, encoding='utf-8', bufsize=1)
+            for line in iter(process.stdout.readline, ''):
+                line = line.strip()
+                if line:
+                    logger.debug("FFMPEG: %s", line)
+                    data['worker_log'].append(line)
+                    progress = ffmpeg_parser.parse_progress(line)
+                    if progress and 'percent' in progress:
+                        try:
+                            percent_val = float(progress['percent'])
+                            logger.info("FFMPEG progress: {:.2f}%".format(percent_val))
+                        except ValueError:
+                            logger.info("FFMPEG progress: {}".format(progress['percent']))
+            process.stdout.close()
+            process.wait()
+            if process.returncode != 0:
+                logger.error(f"FFmpeg transcoding failed with return code: {process.returncode}. Check worker log for details.")
+                raise subprocess.CalledProcessError(process.returncode, ffmpeg_cmd, output=None, stderr="FFmpeg failed. Check logs in worker_log.")
+        except Exception as e: 
+            logger.error(f"Exception during ffmpeg transcoding: {str(e)}", exc_info=True)
+            if isinstance(e, subprocess.CalledProcessError) and hasattr(e, 'output') and e.output:
+                 data['worker_log'].append("FFMPEG Error Output (from exception): " + str(e.output))
+            raise 
 
-        # Set the parser
-        parser = Parser(logger)
-        parser.set_probe(probe)
-        data['command_progress_parser'] = parser.parse_progress
+        # --- Remux Final MKV (mkvmerge) ---
+        logger.info("Starting final remuxing with mkvmerge.")
+        mkvmerge_remux_cmd = ['mkvmerge', '-o', final_mkv_out,
+                              '--video-tracks', '0', temp_av1_track, 
+                              '--audio-tracks', 'all', 
+                              '--subtitle-tracks', 'all', 
+                              '--attachments', 'all', 
+                              '--chapters', 
+                              abspath]
+        logger.info("Executing mkvmerge remux command: %s", " ".join(mkvmerge_remux_cmd))
+        try:
+            remux_result = subprocess.run(mkvmerge_remux_cmd, capture_output=True, text=True, check=True, encoding='utf-8')
+            logger.info("mkvmerge remux stdout: %s", remux_result.stdout)
+            data['worker_log'].append("mkvmerge remux stdout: " + remux_result.stdout)
+            if remux_result.stderr:
+                logger.info("mkvmerge remux stderr (warnings/info): %s", remux_result.stderr)
+                data['worker_log'].append("mkvmerge remux stderr: " + remux_result.stderr)
+        except subprocess.CalledProcessError as e:
+            logger.error(f"mkvmerge remux failed. Return code: {e.returncode}\nstdout: {e.stdout}\nstderr: {e.stderr}")
+            data['worker_log'].append(f"Error: mkvmerge remux failed. stderr: {e.stderr} stdout: {e.stdout}")
+            raise
 
-        if settings.get_setting('force_transcode'):
-            cache_directory = os.path.dirname(data.get('file_out'))
-            if not os.path.exists(cache_directory):
-                os.makedirs(cache_directory)
-            with open(os.path.join(cache_directory, '.force_transcode'), 'w') as f:
-                f.write('')
+        logger.info("Demux-transcode-remux process completed successfully for: %s", final_mkv_out)
 
-    return
-
+    except Exception as e:
+        logger.error(f"An error occurred during the demux-transcode-remux process: {str(e)}", exc_info=True)
+        data['worker_log'].append("Fatal error in processing: " + str(e))
+        # Re-raising the exception ensures Unmanic handles it as a task failure.
+        # The 'finally' block will execute for cleanup.
+        raise 
+    finally:
+        # Ensure temp_dir_path is defined even if an early error occurred before its assignment
+        if 'temp_dir_path' in locals() and os.path.exists(temp_dir_path):
+            logger.info("Cleaning up temporary directory: %s", temp_dir_path)
+            shutil.rmtree(temp_dir_path, ignore_errors=True)
+            logger.info("Temporary directory cleanup finished.")
+        else:
+            logger.info("Temporary directory was not created or already cleaned up.")
+            
+    return # End of on_worker_process
 
 def on_postprocessor_task_results(data):
     """


### PR DESCRIPTION
This commit introduces several significant enhancements to the video_transcoder_studyfranco plugin for Unmanic:

1.  **Fix Option Handling & Expose Advanced SVT-AV1 Parameters:**
    *   Ensured all plugin options (preset, CRF) are correctly parsed and
        applied for the libsvtav1 encoder.
    *   Exposed advanced SVT-AV1 encoding parameters for you in
        'advanced' mode:
        *   `sc_detection` (Scene Change Detection)
        *   `g` (GOP size)
        *   `svtav1-params` (Custom SVT-AV1 parameter string)
        *   `preset` (SVT-AV1 quality/speed preset)
        *   `crf` (Constant Rate Factor)
    *   Added corresponding UI elements (dropdowns, text inputs) for these
        advanced options, visible only in advanced mode.
    *   Updated `LibsvtAv1Encoder.py` to handle these new parameters and
        generate appropriate ffmpeg command line arguments.
    *   Confirmed `plugin.py` correctly loads and displays these new
        settings due to its dynamic nature.

2.  **Preserve HDR Metadata:**
    *   Implemented detection of HDR metadata from the source video using
        ffprobe. This includes:
        *   Color primaries (e.g., Rec.2020)
        *   Transfer characteristics (e.g., PQ/SMPTE ST 2084, HLG)
        *   Color space
        *   Mastering display metadata (SMPTE ST 2086), with correct
          parsing, scaling, and formatting for ffmpeg.
        *   Content light level (MaxCLL/MaxFALL) metadata, with correct
          parsing and formatting.
    *   Added logic to pass this detected metadata to ffmpeg via the
        correct command-line flags (`-color_primaries`, `-color_trc`,
        `-colorspace`, `-master_display`, `-max_cll`) when encoding
        with libsvtav1, ensuring HDR information is preserved in the
        AV1 output.

3.  **Revise Processing Workflow (Demux/Transcode/Remux):**
    *   Changed the plugin's core processing to a three-stage approach:
        1.  **Demux:** `mkvmerge` is used to extract the primary video
            track from the input file into a temporary file.
        2.  **Transcode:** `ffmpeg` is then run *only* on this demuxed
            video track to perform the AV1 encoding using libsvtav1 (with
            all configured options and HDR metadata). Progress parsing is
            handled for this stage.
        3.  **Remux:** `mkvmerge` is used again to assemble a new MKV file,
            combining the newly encoded AV1 video track with *all* other
            original tracks (audio, subtitles, attachments, chapters)
            from the input file.
    *   This new workflow ensures that only the video is processed,
        preserving the integrity and original characteristics of all other
        tracks.
    *   Implemented robust temporary file management and cleanup.
    *   Enhanced logging and error handling for each step of the new
        workflow.

These changes significantly improve the flexibility, quality, and correctness of video transcoding operations, especially for AV1 and HDR content.

# Pull request

## Description of the pull request

<!--- Provide a short summary of submitted plugin in case PR is a new addition. -->
<!--- If PR is plugin update only highlight biggest changes if needed. -->
<!--- Make sure you follow the checklist below before finalising your pull-request. -->

## CLA

- [ ] I agree that by opening a pull requests I am handing over copyright ownership 
of my work contained in that pull request to the owner of this git project. 
My contribution will become licensed under the same license as the overall project. 
This extends upon paragraph 11 of the Terms & Conditions stipulated in the GPL v3.0


## Checklist 

<!--- Go over all the following points, and put an `x` in all the boxes that apply like this: [X] -->
<!--- If you're unsure about any of these, don't hesitate to ask. -->

- [ ] I have ensured that my pull request is being opened to merge into the correct branch.

- [ ] (If submitting a new plugin) I have included a copy of the GPL v3.0 [LICENSE](../LICENSE) 
file in my plugin directory.

- [ ] I have ensured that all new python file contributions contain the correct header as 
stipulated in the [Contributing Docs](CONTRIBUTING.md#opening-pull-requests).
